### PR TITLE
upload-tofu-artifact

### DIFF
--- a/.github/actions/opentofu/action.yml
+++ b/.github/actions/opentofu/action.yml
@@ -127,6 +127,7 @@ runs:
       shell: bash
 
     - name: Upload Terraform output
+      if: ${{ inputs.apply == 'true' }} 
       uses: actions/upload-artifact@v4
       with:
         name: tf-output

--- a/.github/actions/opentofu/action.yml
+++ b/.github/actions/opentofu/action.yml
@@ -120,3 +120,14 @@ runs:
       run: tofu apply -auto-approve
       shell: bash
       working-directory: ${{ env.tf_actions_working_dir }}
+
+    - name: Save OpenTofu output
+      if: ${{ inputs.apply == 'true' }}
+      run: tofu output -json > tf_output.json
+      shell: bash
+
+    - name: Upload Terraform output
+      uses: actions/upload-artifact@v4
+      with:
+        name: tf-output
+        path: tf_output.json


### PR DESCRIPTION
## Changes

- Since the Ansible job needs the server IP created as a Terraform output, create that artifact when doing a terraform apply so that it's available in the Ansible deploy job