### PR TITLE
ensure-hardening-after-cloud-init

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -141,7 +141,7 @@ jobs:
 
             *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ env.tf_actions_working_dir }}\`, Workflow: \`${{ github.workflow }}\`*
 
-            *Last updated: ${new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' })}*`;
+            *Last updated: ${new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' })} CST*`;
 
             // 3. If we have a comment, update it, otherwise create a new one
             if (botComment) {

--- a/opentofu/cloud-init.yaml.tpl
+++ b/opentofu/cloud-init.yaml.tpl
@@ -22,11 +22,12 @@ packages:
 package_update: true
 package_upgrade: true
 write_files:
-  - path: /etc/ssh/sshd_config.d/ssh-hardening.conf
+  - path: /etc/ssh/sshd_config.d/99-ssh-hardening.conf
     content: |
       PermitRootLogin no
       PasswordAuthentication no
       Port 2222
+      PubkeyAuthentication yes
       KbdInteractiveAuthentication no
       ChallengeResponseAuthentication no
       MaxAuthTries 2


### PR DESCRIPTION
## Changes

- A file named `/etc/ssh/sshd_config.d/50-cloud-init.conf` is automatically created which allows password authentication
- That file was overriding ssh-hardening.conf so I added a 99- prefix to have ssh-hardening.conf override the cloud init conf.